### PR TITLE
Adds new config option: connectionString

### DIFF
--- a/packages/docusaurus-plugin-application-insights/jest.config.js
+++ b/packages/docusaurus-plugin-application-insights/jest.config.js
@@ -1,0 +1,7 @@
+/** @type {import('ts-jest').JestConfigWithTsJest} */
+module.exports = {
+    testEnvironment: "node",
+    transform: {
+        "^.+\\.(t|j)sx?$": ["@swc/jest"],
+    },
+};

--- a/packages/docusaurus-plugin-application-insights/package.json
+++ b/packages/docusaurus-plugin-application-insights/package.json
@@ -14,6 +14,7 @@
     "scripts": {
         "clear": "rm -Rf lib",
         "build": "tsc --build",
+        "test": "jest",
         "watch": "tsc --build --watch"
     },
     "repository": {
@@ -33,6 +34,10 @@
         "node": ">=16.14"
     },
     "devDependencies": {
+        "@swc/core": "^1.3.25",
+        "@swc/jest": "^0.2.24",
+        "@types/jest": "^29.2.5",
+        "jest": "^29.3.1",
         "typescript": "^4.9.5"
     },
     "files": [

--- a/packages/docusaurus-plugin-application-insights/src/__tests__/options.test.ts
+++ b/packages/docusaurus-plugin-application-insights/src/__tests__/options.test.ts
@@ -1,0 +1,134 @@
+import { normalizePluginOptions } from "@docusaurus/utils-validation";
+import { validateOptions } from "../index";
+import { Options, ApplicationInsightsOptions } from "../options";
+import type { Validate } from "@docusaurus/types";
+
+function testValidateOptions(options: Options) {
+    return validateOptions({
+        validate: normalizePluginOptions as Validate<
+            Options,
+            ApplicationInsightsOptions
+        >,
+        options,
+    });
+}
+
+describe("application-insights options", () => {
+    it("throws for undefined options", () => {
+        expect(
+            // @ts-expect-error: TS should error
+            () => testValidateOptions(undefined)
+        ).toThrowErrorMatchingInlineSnapshot(
+            `""value" must contain at least one of [instrumentationKey, connectionString]"`
+        );
+    });
+
+    it("throws for null options", () => {
+        expect(
+            // @ts-expect-error: TS should error
+            () => testValidateOptions(null)
+        ).toThrowErrorMatchingInlineSnapshot(
+            `""value" must be of type object"`
+        );
+    });
+
+    it("throws for empty object options", () => {
+        expect(() =>
+            testValidateOptions({})
+        ).toThrowErrorMatchingInlineSnapshot(
+            `""value" must contain at least one of [instrumentationKey, connectionString]"`
+        );
+    });
+
+    it("throws for number options", () => {
+        expect(
+            // @ts-expect-error: TS should error
+            () => testValidateOptions(42)
+        ).toThrowErrorMatchingInlineSnapshot(
+            `""value" must be of type object"`
+        );
+    });
+
+    it("throws for null instrumentationKey", () => {
+        expect(
+            // @ts-expect-error: TS should error
+            () => testValidateOptions({ instrumentationKey: null })
+        ).toThrowErrorMatchingInlineSnapshot(
+            `""instrumentationKey" must be a string"`
+        );
+    });
+
+    it("throws for number instrumentationKey", () => {
+        expect(
+            // @ts-expect-error: TS should error
+            () => testValidateOptions({ instrumentationKey: 42 })
+        ).toThrowErrorMatchingInlineSnapshot(
+            `""instrumentationKey" must be a string"`
+        );
+    });
+
+    it("throws for null connectionString", () => {
+        expect(
+            // @ts-expect-error: TS should error
+            () => testValidateOptions({ connectionString: null })
+        ).toThrowErrorMatchingInlineSnapshot(
+            `""connectionString" must be a string"`
+        );
+    });
+
+    it("throws for number connectionString", () => {
+        expect(
+            // @ts-expect-error: TS should error
+            () => testValidateOptions({ connectionString: 42 })
+        ).toThrowErrorMatchingInlineSnapshot(
+            `""connectionString" must be a string"`
+        );
+    });
+
+    it("validates missing options", () => {
+        let options = {};
+
+        expect(() => {
+            testValidateOptions(options);
+        }).toThrowErrorMatchingInlineSnapshot(
+            `""value" must contain at least one of [instrumentationKey, connectionString]"`
+        );
+    });
+
+    it("validates if xor options are used together", () => {
+        let options = {
+            instrumentationKey: "KEY",
+            connectionString: "CONNECTION_STRING",
+        };
+
+        expect(() => {
+            testValidateOptions(options);
+        }).toThrowErrorMatchingInlineSnapshot(
+            `""value" contains a conflict between exclusive peers [instrumentationKey, connectionString]"`
+        );
+    });
+
+    it.each([
+        [
+            "instrumentationKey",
+            {
+                instrumentationKey: "KEY",
+                connectionString: "",
+            },
+            { id: "default", instrumentationKey: "KEY" },
+        ],
+        [
+            "connectionString",
+            {
+                instrumentationKey: "",
+                connectionString: "CONNECTION_STRING",
+            },
+            { id: "default", connectionString: "CONNECTION_STRING" },
+        ],
+    ])(
+        "validates if %s option is individually valid",
+        (_, options, expected) => {
+            expect(testValidateOptions(options)).toEqual(expected);
+        }
+    );
+});

--- a/packages/docusaurus-plugin-application-insights/src/index.ts
+++ b/packages/docusaurus-plugin-application-insights/src/index.ts
@@ -4,7 +4,7 @@ import type {
     Plugin,
     OptionValidationContext,
 } from "@docusaurus/types";
-import type { ApplicationInsightsOptions, Options } from "./options";
+import { ApplicationInsightsOptions, Options } from "./options";
 import { resolve } from "node:path";
 
 export default function pluginApplicationInsights(
@@ -38,8 +38,9 @@ export default function pluginApplicationInsights(
 }
 
 const pluginOptionsSchema = Joi.object<ApplicationInsightsOptions>({
-    instrumentationKey: Joi.string().required(),
-});
+    instrumentationKey: Joi.string().empty(""),
+    connectionString: Joi.string().empty(""),
+}).xor("instrumentationKey", "connectionString");
 
 export function validateOptions({
     validate,

--- a/packages/docusaurus-plugin-application-insights/src/options.ts
+++ b/packages/docusaurus-plugin-application-insights/src/options.ts
@@ -1,5 +1,6 @@
 export type ApplicationInsightsOptions = {
-  instrumentationKey: string;
+    instrumentationKey: string;
+    connectionString: string;
 };
 
 export type Options = Partial<ApplicationInsightsOptions>;


### PR DESCRIPTION
## Summary

The `docusaurus-plugin-application-insights` plugin's current options include only the `instrumentationKey` option, which is slated for [deprecation in 2025](https://learn.microsoft.com/en-us/azure/azure-monitor/app/sdk-connection-string?tabs=net#overview). This PR adds support for Connection strings, which is the new way to define where to send telemetry data.

New options type:

```ts
export type ApplicationInsightsOptions = {
    instrumentationKey: string;
    connectionString: string;
};
```

These options are mutually exclusive.
