### PR TITLE
fix: renaming to docusaurus-plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased (2023-03-19)
 
 #### :house: Internal
-* [#17](https://github.com/microsoft/docusaurus-plugins-rise4fun/pull/17) Adds Volta configuration to specify node version ([@scalvert](https://github.com/scalvert))
+* [#17](https://github.com/microsoft/docusaurus-plugins/pull/17) Adds Volta configuration to specify node version ([@scalvert](https://github.com/scalvert))
 
 #### Committers: 1
 - Steve Calvert ([@scalvert](https://github.com/scalvert))
@@ -13,7 +13,7 @@
 
 #### :house: Internal
 * `docusaurus-plugin-application-insights`, `docusaurus-plugin-rise4fun`, `docusaurus-remark-plugin-compile-code`, `docusaurus-theme-codesandbox-button`, `docusaurus-theme-side-editor`
-  * [#13](https://github.com/microsoft/docusaurus-plugins-rise4fun/pull/13) feat: puppeteer support ([@pelikhan](https://github.com/pelikhan))
+  * [#13](https://github.com/microsoft/docusaurus-plugins/pull/13) feat: puppeteer support ([@pelikhan](https://github.com/pelikhan))
 
 #### Committers: 1
 - Peli de Halleux ([@pelikhan](https://github.com/pelikhan))
@@ -23,7 +23,7 @@
 
 #### :house: Internal
 * `docusaurus-plugin-application-insights`, `docusaurus-plugin-rise4fun`, `docusaurus-remark-plugin-compile-code`, `docusaurus-theme-codesandbox-button`, `docusaurus-theme-side-editor`
-  * [#13](https://github.com/microsoft/docusaurus-plugins-rise4fun/pull/13) feat: puppeteer support ([@pelikhan](https://github.com/pelikhan))
+  * [#13](https://github.com/microsoft/docusaurus-plugins/pull/13) feat: puppeteer support ([@pelikhan](https://github.com/pelikhan))
 
 #### Committers: 1
 - Peli de Halleux ([@pelikhan](https://github.com/pelikhan))
@@ -33,7 +33,7 @@
 
 #### :house: Internal
 * `docusaurus-plugin-application-insights`, `docusaurus-plugin-rise4fun`, `docusaurus-remark-plugin-compile-code`, `docusaurus-theme-codesandbox-button`, `docusaurus-theme-side-editor`
-  * [#13](https://github.com/microsoft/docusaurus-plugins-rise4fun/pull/13) feat: puppeteer support ([@pelikhan](https://github.com/pelikhan))
+  * [#13](https://github.com/microsoft/docusaurus-plugins/pull/13) feat: puppeteer support ([@pelikhan](https://github.com/pelikhan))
 
 #### Committers: 1
 - Peli de Halleux ([@pelikhan](https://github.com/pelikhan))
@@ -43,7 +43,7 @@
 
 #### :house: Internal
 * `docusaurus-plugin-application-insights`, `docusaurus-plugin-rise4fun`, `docusaurus-remark-plugin-compile-code`, `docusaurus-theme-codesandbox-button`, `docusaurus-theme-side-editor`
-  * [#13](https://github.com/microsoft/docusaurus-plugins-rise4fun/pull/13) feat: puppeteer support ([@pelikhan](https://github.com/pelikhan))
+  * [#13](https://github.com/microsoft/docusaurus-plugins/pull/13) feat: puppeteer support ([@pelikhan](https://github.com/pelikhan))
 
 #### Committers: 1
 - Peli de Halleux ([@pelikhan](https://github.com/pelikhan))
@@ -53,7 +53,7 @@
 
 #### :house: Internal
 * `docusaurus-plugin-application-insights`, `docusaurus-plugin-rise4fun`, `docusaurus-remark-plugin-compile-code`, `docusaurus-theme-codesandbox-button`, `docusaurus-theme-side-editor`
-  * [#13](https://github.com/microsoft/docusaurus-plugins-rise4fun/pull/13) feat: puppeteer support ([@pelikhan](https://github.com/pelikhan))
+  * [#13](https://github.com/microsoft/docusaurus-plugins/pull/13) feat: puppeteer support ([@pelikhan](https://github.com/pelikhan))
 
 #### Committers: 1
 - Peli de Halleux ([@pelikhan](https://github.com/pelikhan))
@@ -63,7 +63,7 @@
 
 #### :house: Internal
 * `docusaurus-plugin-application-insights`, `docusaurus-plugin-rise4fun`, `docusaurus-remark-plugin-compile-code`, `docusaurus-theme-codesandbox-button`, `docusaurus-theme-side-editor`
-  * [#13](https://github.com/microsoft/docusaurus-plugins-rise4fun/pull/13) feat: puppeteer support ([@pelikhan](https://github.com/pelikhan))
+  * [#13](https://github.com/microsoft/docusaurus-plugins/pull/13) feat: puppeteer support ([@pelikhan](https://github.com/pelikhan))
 
 #### Committers: 1
 - Peli de Halleux ([@pelikhan](https://github.com/pelikhan))
@@ -73,7 +73,7 @@
 
 #### :rocket: Enhancement
 * `docusaurus-remark-plugin-compile-code`
-  * [#2](https://github.com/microsoft/docusaurus-plugins-rise4fun/pull/2) feat: async compile code ([@pelikhan](https://github.com/pelikhan))
+  * [#2](https://github.com/microsoft/docusaurus-plugins/pull/2) feat: async compile code ([@pelikhan](https://github.com/pelikhan))
 
 #### Committers: 1
 - Peli de Halleux ([@pelikhan](https://github.com/pelikhan))
@@ -83,7 +83,7 @@
 
 #### :rocket: Enhancement
 * `docusaurus-remark-plugin-compile-code`
-  * [#2](https://github.com/microsoft/docusaurus-plugins-rise4fun/pull/2) feat: async compile code ([@pelikhan](https://github.com/pelikhan))
+  * [#2](https://github.com/microsoft/docusaurus-plugins/pull/2) feat: async compile code ([@pelikhan](https://github.com/pelikhan))
 
 #### Committers: 1
 - Peli de Halleux ([@pelikhan](https://github.com/pelikhan))

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repository contains plugins for Docusaurus to support creating rich documentation for programming languages tools.
 
--   [Read the documentation](https://microsoft.github.io/docusaurus-plugins-rise4fun).
+-   [Read the documentation](https://microsoft.github.io/docusaurus-plugins).
 
 ## Development
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "repository": {
     "type": "git",
-    "url": "https://github.com/microsoft/docusaurus-plugins-rise4fun.git"
+    "url": "https://github.com/microsoft/docusaurus-plugins.git"
   },
   "workspaces": [
     "packages/*",

--- a/packages/docusaurus-plugin-application-insights/README.md
+++ b/packages/docusaurus-plugin-application-insights/README.md
@@ -4,4 +4,4 @@ Docusaurus plugin to support Microsoft Application Insights ([npm.js](https://ww
 
 ## Usage
 
-See [docusaurus-plugin-application-insights documentation](https://microsoft.github.io/docusaurus-plugins-rise4fun/docs/plugins/application-insights).
+See [docusaurus-plugin-application-insights documentation](https://microsoft.github.io/docusaurus-plugins/docs/plugins/application-insights).

--- a/packages/docusaurus-plugin-application-insights/package.json
+++ b/packages/docusaurus-plugin-application-insights/package.json
@@ -19,7 +19,7 @@
     },
     "repository": {
         "type": "git",
-        "url": "https://github.com/microsoft/docusaurus-plugins-rise4fun.git",
+        "url": "https://github.com/microsoft/docusaurus-plugins.git",
         "directory": "packages/docusaurus-plugin-application-insights"
     },
     "license": "MIT",

--- a/packages/docusaurus-plugin-rise4fun/README.md
+++ b/packages/docusaurus-plugin-rise4fun/README.md
@@ -1,7 +1,7 @@
-# `@rise4fun/docusaurus-plugins-rise4fun`
+# `@rise4fun/docusaurus-plugins`
 
 Docusaurus plugin for Microsoft Research Rise4fun web sites ([npm.js](https://www.npmjs.com/package/@rise4fun/docusaurus-plugin-rise4fun)).
 
 ## Usage
 
-See [docusaurus-plugin-rise4fun documentation](https://microsoft.github.io/docusaurus-plugins-rise4fun/docs/plugins/).
+See [docusaurus-plugin-rise4fun documentation](https://microsoft.github.io/docusaurus-plugins/docs/plugins/).

--- a/packages/docusaurus-plugin-rise4fun/package.json
+++ b/packages/docusaurus-plugin-rise4fun/package.json
@@ -14,7 +14,7 @@
     },
     "repository": {
         "type": "git",
-        "url": "https://github.com/microsoft/docusaurus-plugins-rise4fun.git",
+        "url": "https://github.com/microsoft/docusaurus-plugins.git",
         "directory": "packages/docusaurus-plugin-rise4fun"
     },
     "license": "MIT",

--- a/packages/docusaurus-remark-plugin-code-element/README.md
+++ b/packages/docusaurus-remark-plugin-code-element/README.md
@@ -4,4 +4,4 @@ Docusaurus plugin to convert fenced code section into MDX snippets ([npm.js](htt
 
 ## Usage
 
-See [docusaurus-remark-plugin-code-element documentation](https://microsoft.github.io/docusaurus-plugins-rise4fun/docs/plugins/docusaurus-remark-plugin-code-element).
+See [docusaurus-remark-plugin-code-element documentation](https://microsoft.github.io/docusaurus-plugins/docs/plugins/docusaurus-remark-plugin-code-element).

--- a/packages/docusaurus-remark-plugin-code-element/package.json
+++ b/packages/docusaurus-remark-plugin-code-element/package.json
@@ -20,7 +20,7 @@
     },
     "repository": {
         "type": "git",
-        "url": "https://github.com/microsoft/docusaurus-plugins-rise4fun.git",
+        "url": "https://github.com/microsoft/docusaurus-plugins.git",
         "directory": "packages/docusaurus-remark-plugin-code-element"
     },
     "license": "MIT",

--- a/packages/docusaurus-remark-plugin-code-tabs/README.md
+++ b/packages/docusaurus-remark-plugin-code-tabs/README.md
@@ -4,4 +4,4 @@ Docusaurus remark plugin that assembles code sections into tabs, with optional C
 
 ## Usage
 
-See [docusaurus-remark-plugin-code-tabs documentation](https://microsoft.github.io/docusaurus-plugins-rise4fun/docs/plugins/docusaurus-remark-plugin-code-tabs).
+See [docusaurus-remark-plugin-code-tabs documentation](https://microsoft.github.io/docusaurus-plugins/docs/plugins/docusaurus-remark-plugin-code-tabs).

--- a/packages/docusaurus-remark-plugin-code-tabs/package.json
+++ b/packages/docusaurus-remark-plugin-code-tabs/package.json
@@ -20,7 +20,7 @@
     },
     "repository": {
         "type": "git",
-        "url": "https://github.com/microsoft/docusaurus-plugins-rise4fun.git",
+        "url": "https://github.com/microsoft/docusaurus-plugins.git",
         "directory": "packages/docusaurus-remark-plugin-code-tabs"
     },
     "license": "MIT",

--- a/packages/docusaurus-remark-plugin-compile-code/README.md
+++ b/packages/docusaurus-remark-plugin-compile-code/README.md
@@ -4,4 +4,4 @@ Docusaurus plugin to run a tool against code snippets at build time ([npm.js](ht
 
 ## Usage
 
-See [docusaurus-remark-plugin-compile-code documentation](https://microsoft.github.io/docusaurus-plugins-rise4fun/docs/plugins/docusaurus-remark-plugin-compile-code).
+See [docusaurus-remark-plugin-compile-code documentation](https://microsoft.github.io/docusaurus-plugins/docs/plugins/docusaurus-remark-plugin-compile-code).

--- a/packages/docusaurus-remark-plugin-compile-code/package.json
+++ b/packages/docusaurus-remark-plugin-compile-code/package.json
@@ -20,7 +20,7 @@
     },
     "repository": {
         "type": "git",
-        "url": "https://github.com/microsoft/docusaurus-plugins-rise4fun.git",
+        "url": "https://github.com/microsoft/docusaurus-plugins.git",
         "directory": "packages/docusaurus-remark-plugin-compile-code"
     },
     "license": "MIT",

--- a/packages/docusaurus-remark-plugin-import-file/README.md
+++ b/packages/docusaurus-remark-plugin-import-file/README.md
@@ -4,4 +4,4 @@ Docusaurus plugin to import markdown files ([npm.js](https://www.npmjs.com/packa
 
 ## Usage
 
-See [docusaurus-remark-plugin-import-file documentation](https://microsoft.github.io/docusaurus-plugins-rise4fun/docs/plugins/docusaurus-remark-plugin-import-files).
+See [docusaurus-remark-plugin-import-file documentation](https://microsoft.github.io/docusaurus-plugins/docs/plugins/docusaurus-remark-plugin-import-files).

--- a/packages/docusaurus-remark-plugin-import-file/package.json
+++ b/packages/docusaurus-remark-plugin-import-file/package.json
@@ -20,7 +20,7 @@
     },
     "repository": {
         "type": "git",
-        "url": "https://github.com/microsoft/docusaurus-plugins-rise4fun.git",
+        "url": "https://github.com/microsoft/docusaurus-plugins.git",
         "directory": "packages/docusaurus-remark-plugin-import-file"
     },
     "license": "MIT",

--- a/packages/docusaurus-remark-plugin-side-editor/README.md
+++ b/packages/docusaurus-remark-plugin-side-editor/README.md
@@ -4,4 +4,4 @@ Docusaurus remark plugin that injects `Edit` button after code section that open
 
 ## Usage
 
-See [docusaurus-remark-plugin-side-editor documentation](https://microsoft.github.io/docusaurus-plugins-rise4fun/docs/plugins/docusaurus-remark-plugin-side-editor).
+See [docusaurus-remark-plugin-side-editor documentation](https://microsoft.github.io/docusaurus-plugins/docs/plugins/docusaurus-remark-plugin-side-editor).

--- a/packages/docusaurus-remark-plugin-side-editor/package.json
+++ b/packages/docusaurus-remark-plugin-side-editor/package.json
@@ -20,7 +20,7 @@
     },
     "repository": {
         "type": "git",
-        "url": "https://github.com/microsoft/docusaurus-plugins-rise4fun.git",
+        "url": "https://github.com/microsoft/docusaurus-plugins.git",
         "directory": "packages/docusaurus-remark-plugin-side-editor"
     },
     "license": "MIT",

--- a/packages/docusaurus-theme-codesandbox-button/README.md
+++ b/packages/docusaurus-theme-codesandbox-button/README.md
@@ -6,4 +6,4 @@ Docusaurus theme component that displays a button to create/open a CodeSandbox p
 
 ## Usage
 
-See [documentation](https://microsoft.github.io/docusaurus-plugins-rise4fun/docs/plugins/docusaurus-theme-codesandbox-button).
+See [documentation](https://microsoft.github.io/docusaurus-plugins/docs/plugins/docusaurus-theme-codesandbox-button).

--- a/packages/docusaurus-theme-codesandbox-button/package.json
+++ b/packages/docusaurus-theme-codesandbox-button/package.json
@@ -26,7 +26,7 @@
     },
     "repository": {
         "type": "git",
-        "url": "https://github.com/microsoft/docusaurus-plugins-rise4fun.git",
+        "url": "https://github.com/microsoft/docusaurus-plugins.git",
         "directory": "packages/docusaurus-theme-codesandbox-button"
     },
     "license": "MIT",

--- a/packages/docusaurus-theme-side-editor/README.md
+++ b/packages/docusaurus-theme-side-editor/README.md
@@ -4,4 +4,4 @@ A Docusaurus theme component that creates a side editor  ([npm.js](https://www.n
 
 ## Usage
 
-See [documentation](https://microsoft.github.io/docusaurus-plugins-rise4fun/docs/plugins/docusaurus-theme-side-editor).
+See [documentation](https://microsoft.github.io/docusaurus-plugins/docs/plugins/docusaurus-theme-side-editor).

--- a/packages/docusaurus-theme-side-editor/package.json
+++ b/packages/docusaurus-theme-side-editor/package.json
@@ -26,7 +26,7 @@
     },
     "repository": {
         "type": "git",
-        "url": "https://github.com/microsoft/docusaurus-plugins-rise4fun.git",
+        "url": "https://github.com/microsoft/docusaurus-plugins.git",
         "directory": "packages/docusaurus-theme-side-editor"
     },
     "license": "MIT",

--- a/website/docs/markdown-features/side-editor.mdx
+++ b/website/docs/markdown-features/side-editor.mdx
@@ -143,7 +143,7 @@ For example, the `msagljs` tool is wrapped as `./static/editors/msagl.html`.
 </html>
 ```
 
-[See how it is done in docusaurus-plugins-rise4fun](https://github.com/microsoft/docusaurus-plugins-rise4fun/blob/main/website/langs/msagl.html)
+[See how it is done in docusaurus-plugins](https://github.com/microsoft/docusaurus-plugins/blob/main/website/langs/msagl.html)
 
 ```js title="./docusaurus.config.js"
 const config = configure({ ... }, {

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -14,11 +14,11 @@ const config = configure(
             "Docusaurus plugins for awesome Programming Language documentation.",
         organizationName: "Microsoft",
         url: "https://microsoft.github.io",
-        baseUrl: "/docusaurus-plugins-rise4fun",
+        baseUrl: "/docusaurus-plugins",
         onBrokenLinks: "throw",
         onBrokenMarkdownLinks: "warn",
         favicon: "img/logo.svg",
-        projectName: "docusaurus-plugins-rise4fun",
+        projectName: "docusaurus-plugins",
         presets: [
             [
                 "classic",

--- a/website/package.json
+++ b/website/package.json
@@ -4,7 +4,7 @@
     "private": true,
     "repository": {
         "type": "git",
-        "url": "https://github.com/microsoft/docusaurus-plugins-rise4fun.git",
+        "url": "https://github.com/microsoft/docusaurus-plugins.git",
         "directory": "website"
     },
     "scripts": {


### PR DESCRIPTION
We'll need to publish this and rename the repo.